### PR TITLE
Add Html.Extra.static

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -7,10 +7,12 @@
         "src"
     ],
     "exposed-modules": [
+        "Html.Extra",
         "Html.Attributes.Extra",
         "Html.Events.Extra"
     ],
     "dependencies": {
+        "elm-community/basics-extra": "1.0.0 <= v < 2.0.0",
         "elm-lang/core": "2.0.0 <= v < 4.0.0",
         "evancz/elm-html": "4.0.0 <= v < 6.0.0"
     },

--- a/src/Html/Extra.elm
+++ b/src/Html/Extra.elm
@@ -1,12 +1,12 @@
 module Html.Extra
     exposing
-        ( embedStatic
+        ( static
         )
 
 {-| Convenience functionality on
 [`Html`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html#Html)
 
-@docs embedStatic
+@docs static
 -}
 
 import Basics.Extra
@@ -23,6 +23,6 @@ it will not generate any messages. We may want to embed such static
 html into arbitrary views, while using types to enforce the
 staticness. That is what this function provides.
 -}
-embedStatic : Html Never -> Html msg
-embedStatic =
+static : Html Never -> Html msg
+static =
     Html.App.map Basics.Extra.never

--- a/src/Html/Extra.elm
+++ b/src/Html/Extra.elm
@@ -1,0 +1,28 @@
+module Html.Extra
+    exposing
+        ( embedStatic
+        )
+
+{-| Convenience functionality on
+[`Html`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html#Html)
+
+@docs embedStatic
+-}
+
+import Basics.Extra
+import Html exposing (Html)
+import Html.App
+
+
+{-| Embedding static html.
+
+The type argument
+[`Never`](http://package.elm-lang.org/packages/elm-lang/core/latest/Basics#Never)
+in `Html Never` tells us that the html has no event handlers attached,
+it will not generate any messages. We may want to embed such static
+html into arbitrary views, while using types to enforce the
+staticness. That is what this function provides.
+-}
+embedStatic : Html Never -> Html msg
+embedStatic =
+    Html.App.map Basics.Extra.never

--- a/src/Html/Extra.elm
+++ b/src/Html/Extra.elm
@@ -22,6 +22,10 @@ in `Html Never` tells us that the html has no event handlers attached,
 it will not generate any messages. We may want to embed such static
 html into arbitrary views, while using types to enforce the
 staticness. That is what this function provides.
+
+*Note:* To call this function, the argument need not be literally of type
+`Html Never`. It suffices if it is a fully polymorphic (in the message type)
+`Html` value. For example, this works: `static (Html.text "abcdef")`.
 -}
 static : Html Never -> Html msg
 static =


### PR DESCRIPTION
A motivating use case is in [this thread on the mailing list](https://groups.google.com/d/msg/elm-discuss/VDZefdMiupY/INfEJIevCQAJ).

In short:

One may model the case that one has some html that is static (in the sense it never gives rise to an event) by using type `Html Never`. Then, when including that piece of html in a view, one will typically have to transform it into something of type `Html Msg` for an application specific `Msg` type. One way to do so is to use `Html.App.map` with a function of type `Never -> Msg`. Typically `\_ -> NoOp`. But sometimes this may mean one has to artificially introduce `NoOp` into the application specific `Msg` type, which may otherwise not have a need for a `NoOp` concept. Also, it's lame to write down that `\_ -> NoOp` function when it is anyway never going to be actually applied. And moreover, writing `Html.App.map (\_ -> NoOp)` does not actually *enforce* that the input is of type `Html Never`, it would accept any other `Html Whatever` as well.

The function `static : Html Never -> Html msg` here remedies all that.

For example, we then have that `static (Html.text "abcdef")` has type `Html Msg` for whatever `Msg` type we want, and at the same time we have expressed that the html being embedded there is not allowed to ever actually emit any messages (even if one later refactors and replaces `Html.text "abcdef"` by another expression or by an argument of the view function, for example).