### PR TITLE
Use keypress instead of keyup in onEnter

### DIFF
--- a/src/Html/Events/Extra.elm
+++ b/src/Html/Events/Extra.elm
@@ -261,12 +261,12 @@ onClickPreventDefaultAndStopPropagation msg =
         (Json.succeed msg)
 
 
-{-| When the enter key is released, send the `msg`.
+{-| When the enter key is pressed, send the `msg`.
     Otherwise, do nothing.
 -}
 onEnter : msg -> Attribute msg
 onEnter onEnterAction =
-    on "keyup" <|
+    on "keypress" <|
         Json.andThen
             (\keyCode ->
                 if keyCode == 13 then


### PR DESCRIPTION
This is a problem specific to a particular situation.

Japanese text are input by pressing Enter key **twice**.

1. Choose correct letters
2. Finish editing

The problem is that `onEnter` handles event on the timing (1) instead of (2).

For example, when we Japanese type `kansuu`, there are many way to express it. (1) Show `kansuu` directly (2) convert to `かんすう` (3) convert to `関数` (4) convert to `巻数`... This functionality is called IME (Input Method Editor).

![screen shot 2018-01-27 at 23 10 15](https://user-images.githubusercontent.com/2568148/35472709-8412d878-03b7-11e8-9825-be3a04a25a64.png)

When we want to input "関数って最高だよね",  we first type `kansuu` and then choose `関数` using Enter key. Now we haven't finished inputting the whole text yet, but `onEnter` event is unexpectedly emitted.

As far as I know, using `keypress` instead of `keyup` solves this problem. But I'm not sure if this change causes any downside or not. I will really appreciate if someone could review this.