### PR TITLE
Fix to expose `charCode` correctly

### DIFF
--- a/src/Html/Events/Extra.elm
+++ b/src/Html/Events/Extra.elm
@@ -17,7 +17,7 @@ module Html.Events.Extra exposing
 
   - TODO: `KeyEvent`, `keyEvent`
 
-    @docs charCode
+@docs charCode
 
 
 # Typed event decoders


### PR DESCRIPTION
I guess it unintendedly does not expose `charCode`.