### PR TITLE
Add Html.Attributes.Extra.empty

### DIFF
--- a/src/Html/Attributes/Extra.elm
+++ b/src/Html/Attributes/Extra.elm
@@ -1,6 +1,6 @@
 module Html.Attributes.Extra exposing
     ( static
-    , empty
+    , empty, attributeIf, attributeMaybe
     , valueAsFloat, valueAsInt, autocomplete
     , role
     , low, high, optimum
@@ -19,9 +19,9 @@ module Html.Attributes.Extra exposing
 @docs static
 
 
-# No-op attribute
+# Conditional attribute handling
 
-@docs empty
+@docs empty, attributeIf, attributeMaybe
 
 
 # Inputs
@@ -128,6 +128,26 @@ or adding an extra trailing space in the `class` attribute if added after
 empty : Attribute msg
 empty =
     Html.Attributes.classList []
+
+
+{-| A function to only render a HTML attribute under a certain condition
+-}
+attributeIf : Bool -> Attribute msg -> Attribute msg
+attributeIf condition attr =
+    if condition then
+        attr
+
+    else
+        empty
+
+
+{-| Renders `empty` attribute in case of Nothing, uses the provided function in case of Just.
+-}
+attributeMaybe : (a -> Attribute msg) -> Maybe a -> Attribute msg
+attributeMaybe fn maybeThing =
+    maybeThing
+        |> Maybe.map fn
+        |> Maybe.withDefault empty
 
 
 {-| Create arbitrary string _properties_.

--- a/src/Html/Attributes/Extra.elm
+++ b/src/Html/Attributes/Extra.elm
@@ -1,5 +1,6 @@
 module Html.Attributes.Extra exposing
     ( static
+    , empty
     , valueAsFloat, valueAsInt, autocomplete
     , role
     , low, high, optimum
@@ -16,6 +17,11 @@ module Html.Attributes.Extra exposing
 # Embedding static attributes
 
 @docs static
+
+
+# No-op attribute
+
+@docs empty
 
 
 # Inputs
@@ -61,6 +67,67 @@ Works alike to [`Html.Extra.static`](Html-Extra#static).
 static : Attribute Never -> Attribute msg
 static =
     Html.Attributes.map never
+
+
+{-| A no-op attribute.
+
+Allows for patterns like:
+
+    Html.div
+        [ someAttr
+        , if someCondition then
+            empty
+
+          else
+            someAttr2
+        ]
+        [ someHtml ]
+
+instead of
+
+    Html.div
+        (someAttr
+            :: (if someCondition then
+                    []
+
+                else
+                    [ someAttr2 ]
+               )
+        )
+        [ someHtml ]
+
+This is useful eg. for conditional event handlers.
+
+---
+
+The only effect it can have on the resulting DOM is adding a `class` attribute,
+or adding an extra trailing space in the `class` attribute if added after
+`Html.Attribute.class` or `Html.Attribute.classList`:
+
+    -- side effect 1:
+    -- <div class="" />
+    Html.div [ empty ] []
+
+    -- side effect 2:
+    -- <div class="x " />
+    Html.div [ class "x", empty ] []
+
+    -- no side effect:
+    -- <div class="x" />
+    Html.div [ empty, class "x" ] []
+
+    -- side effect 2:
+    -- <div class="x " />
+    Html.div [ classList [ ( "x", True ) ], empty ] []
+
+    -- no side effect:
+    -- <div class="x" />
+    Html.div [ empty, classList [ ( "x", True ) ] ] []
+
+-}
+empty : Attribute msg
+empty =
+    Html.Attributes.classList []
 
 
 {-| Create arbitrary string _properties_.


### PR DESCRIPTION
Would `noOp` be a better name? `nothing`? (That one would probably clash with `Html.Extra.nothing` if people imported using `(..)` ...)

Here's the side effects Ellie: https://ellie-app.com/8g8HyJvGPS4a1