### PR TITLE
Detect input events on multi-choice select elements

### DIFF
--- a/src/Html/Events/Extra.elm
+++ b/src/Html/Events/Extra.elm
@@ -280,15 +280,15 @@ onChange onChangeAction =
     on "change" <| Json.map onChangeAction targetValue
 
 
-{-| Detect input events on multi-choice select elements.
+{-| Detect change events on multi-choice select elements.
 
-It will grab the string values of `event.target.selectedOptions` on any input
+It will grab the string values of `event.target.selectedOptions` on any change
 event.
 
 Check out [`targetSelectedOptions`](#targetSelectedOptions) for more details on
 how this works.
 
-Note: `Html.Events.onInput` parses `event.target.value` that doesn't work with
+Note: [`onChange`](#onChange) parses `event.target.value` that doesn't work with
 multi-choice select elements.
 
 Note 2:
@@ -298,6 +298,6 @@ is not supported by Internet Explorer.
 -}
 onMultiSelect : (List String -> msg) -> Attribute msg
 onMultiSelect tagger =
-    stopPropagationOn "input" <|
+    stopPropagationOn "change" <|
         Json.map (\x -> ( x, True )) <|
             Json.map tagger targetSelectedOptions

--- a/src/Html/Events/Extra.elm
+++ b/src/Html/Events/Extra.elm
@@ -227,7 +227,7 @@ targetSelectedOptions =
                 Json.keyValuePairs <|
                     Json.field "value" Json.string
     in
-    Json.map (List.map (\( _, value ) -> value)) options
+    Json.map (List.map Tuple.second) options
 
 
 
@@ -299,10 +299,5 @@ is not supported by Internet Explorer.
 onMultiSelect : (List String -> msg) -> Attribute msg
 onMultiSelect tagger =
     stopPropagationOn "input" <|
-        Json.map alwaysStop <|
+        Json.map (\x -> ( x, True )) <|
             Json.map tagger targetSelectedOptions
-
-
-alwaysStop : a -> ( a, Bool )
-alwaysStop x =
-    ( x, True )

--- a/src/Html/Events/Extra.elm
+++ b/src/Html/Events/Extra.elm
@@ -219,15 +219,15 @@ targetSelectedIndex =
 
 {-| Parse `event.target.selectedOptions` and return option values.
 -}
-targetSelectedOptions : Decoder (List String)
+targetSelectedOptions : Json.Decoder (List String)
 targetSelectedOptions =
     let
         options =
-            Decode.at [ "target", "selectedOptions" ] <|
-                Decode.keyValuePairs <|
-                    Decode.field "value" Decode.string
+            Json.at [ "target", "selectedOptions" ] <|
+                Json.keyValuePairs <|
+                    Json.field "value" Json.string
     in
-    Decode.map (List.map (\( _, value ) -> value)) options
+    Json.map (List.map (\( _, value ) -> value)) options
 
 
 


### PR DESCRIPTION
Add Html Event attribute `onMultiSelect` to handle input events on multi-choice select elements.

`Html.Events.onInput` parses `event.target.value` that doesn't work with multi-choice select elements. `onMultiSelect`will grab the string values of `event.target.selectedOptions` parsed by `targetSelectedOptions` on any input event.