### PR TITLE
Fix viewIfLazy documentation

### DIFF
--- a/src/Html/Extra.elm
+++ b/src/Html/Extra.elm
@@ -69,9 +69,9 @@ viewIf condition html =
         div
             []
             [ fieldInput model
-            , viewIf
+            , viewIfLazy
                 (not <| List.isEmpty model.errors)
-                errorsView
+                (\() -> errorsView)
             ]
 
 -}


### PR DESCRIPTION
The `viewIfLazy` documentation was showing the `viewIf` example code