### PR TITLE
Add an elm-review rule to warn of

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -14,7 +14,11 @@
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/html": "1.0.0 <= v < 2.0.0",
-        "elm/json": "1.0.0 <= v < 2.0.0"
+        "elm/json": "1.0.0 <= v < 2.0.0",
+        "jfmengels/elm-review": "2.0.2 <= v < 3.0.0",
+        "stil4m/elm-syntax": "7.1.1 <= v < 8.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+    }
 }

--- a/src/Html/Rules/NoTextEmptyString.elm
+++ b/src/Html/Rules/NoTextEmptyString.elm
@@ -1,0 +1,106 @@
+module Html.Rules.NoTextEmptyString exposing (error, rule)
+
+{-| @doc rule
+-}
+
+import Elm.Syntax.Exposing as Exposing
+import Elm.Syntax.Expression as Expression exposing (Expression)
+import Elm.Syntax.Import exposing (Import)
+import Elm.Syntax.ModuleName exposing (ModuleName)
+import Elm.Syntax.Node as Node exposing (Node)
+import Review.Rule as Rule exposing (Error, Rule)
+
+
+type Context
+    = NoImport
+    | Import { aliasing : Maybe ModuleName, exposed : Bool }
+
+
+rule : Rule
+rule =
+    Rule.newModuleRuleSchema "NoTextEmptyString" NoImport
+        |> Rule.withImportVisitor importVisitor
+        |> Rule.withExpressionVisitor expressionVisitor
+        |> Rule.fromModuleRuleSchema
+
+
+importVisitor : Node Import -> Context -> ( List (Error {}), Context )
+importVisitor node context =
+    case Node.value node |> .moduleName |> Node.value of
+        [ "Html" ] ->
+            ( []
+            , let
+                exposed =
+                    case Node.value node |> .exposingList |> Maybe.map Node.value of
+                        Just (Exposing.All _) ->
+                            True
+
+                        Just (Exposing.Explicit exposedNames) ->
+                            List.any
+                                (\exposedName ->
+                                    case Node.value exposedName of
+                                        Exposing.FunctionExpose "text" ->
+                                            True
+
+                                        _ ->
+                                            False
+                                )
+                                exposedNames
+
+                        Nothing ->
+                            False
+
+                aliasing =
+                    Node.value node |> .moduleAlias |> Maybe.map Node.value
+              in
+              Import { aliasing = aliasing, exposed = exposed }
+            )
+
+        _ ->
+            ( [], context )
+
+
+expressionVisitor : Node Expression -> Rule.Direction -> Context -> ( List (Error {}), Context )
+expressionVisitor expression direction context =
+    case ( direction, context ) of
+        ( Rule.OnEnter, Import { aliasing, exposed } ) ->
+            case Node.value expression of
+                Expression.Application [ function, argument ] ->
+                    case ( Node.value function, Node.value argument ) of
+                        ( Expression.FunctionOrValue [] "text", Expression.Literal "" ) ->
+                            if exposed then
+                                -- then this "text" is `Html.text`
+                                ( [ Rule.error error (Node.range expression) ], context )
+
+                            else
+                                ( [], context )
+
+                        ( Expression.FunctionOrValue moduleName "text", Expression.Literal "" ) ->
+                            if moduleName == (aliasing |> Maybe.withDefault [ "Html" ]) then
+                                ( [ Rule.error error (Node.range expression) ], context )
+
+                            else
+                                ( [], context )
+
+                        _ ->
+                            ( [], context )
+
+                _ ->
+                    ( [], context )
+
+        _ ->
+            -- Either NoImport or not "onEnter"
+            ( [], context )
+
+
+error : { message : String, details : List String }
+error =
+    { message = "Do not use `Html.text \"\"` to represent \"Nothing\""
+    , details =
+        [ "Since your project is using Html.Extra please use one of the following function instead of `Html.text \"\"`"
+        , " - (`Html.Extra.nothing`)[https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Extra#nothing]"
+        , " - (`Html.Extra.viewIf`)[https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Extra#viewIf]"
+        , " - (`Html.Extra.viewMaybe`)[https://www.papillesetpupilles.fr/2019/09/sirop-de-fleurs-sauvages-maison.html/?fbclid=IwAR3BcddwSYAjNyspmabbMNaYyUkbVpsOv81VBYhOd85-XQqnhYYnJzuRWBU]"
+        , " - (`Html.Extra.viewIfLazy`)[https://package.elm-lang.org/packages/elm-community/html-extra/latest/Html-Extra#viewIfLazy]"
+        ]
+    }

--- a/tests/Rules/NoTextEmptyString.elm
+++ b/tests/Rules/NoTextEmptyString.elm
@@ -1,0 +1,120 @@
+module Rules.NoTextEmptyString exposing (suite)
+
+-- import Expect exposing (Expectation)
+
+import Html.Rules.NoTextEmptyString as NoTextEmptyString
+import Review.Test
+import Test exposing (Test, describe, test)
+
+
+suite : Test
+suite =
+    describe "NoTextEmptyString"
+        [ test "should not report anything if there is no `text \"\"` - not even imported " <|
+            \() ->
+                """
+module A exposing (..)
+
+foo : String
+foo = "bar"
+    """
+                    |> Review.Test.run NoTextEmptyString.rule
+                    |> Review.Test.expectNoErrors
+        , test "should not report anything if `text \"\"` is not form Html" <|
+            \() ->
+                """
+module A exposing (..)
+
+import Html
+
+text: String -> String
+text = identity
+
+
+foo : Html.Html msg
+foo = Html.text <| text ""
+    """
+                    |> Review.Test.run NoTextEmptyString.rule
+                    |> Review.Test.expectNoErrors
+        , test "it should detect `Html.text \"\"`" <|
+            \() ->
+                """
+module A exposing (..)
+
+import Html 
+
+foo : Html.Html msg
+foo = Html.text ""
+            """
+                    |> Review.Test.run NoTextEmptyString.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = NoTextEmptyString.error.message
+                            , details = NoTextEmptyString.error.details
+                            , under = "Html.text \"\""
+                            }
+                        ]
+        , test "it should detect `text \"\"`" <|
+            \() ->
+                """
+module A exposing (..)
+
+import Html exposing (text)
+
+foo : Html.Html msg
+foo = text ""
+          """
+                    |> Review.Test.run NoTextEmptyString.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = NoTextEmptyString.error.message
+                            , details = NoTextEmptyString.error.details
+                            , under = "text \"\""
+                            }
+                        ]
+        , test "it should detect `H.text \"\"`" <|
+            \() ->
+                """
+module A exposing (..)
+
+import Html as H exposing (text)
+
+foo : Html.Html msg
+foo = H.text ""
+            """
+                    |> Review.Test.run NoTextEmptyString.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = NoTextEmptyString.error.message
+                            , details = NoTextEmptyString.error.details
+                            , under = "H.text \"\""
+                            }
+                        ]
+        , test "it should detect all possible errors (even though this example doesn't compile)" <|
+            \() ->
+                """
+module A exposing (..)
+
+import Html as H exposing (text)
+
+foo : Html.Html msg
+foo = Html.div [ ] 
+  [H.text ""
+  , text ""
+  , Html.text ""]
+                            """
+                    |> Review.Test.run NoTextEmptyString.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = NoTextEmptyString.error.message
+                            , details = NoTextEmptyString.error.details
+                            , under = "H.text \"\""
+                            }
+                        , Review.Test.error
+                            { message = NoTextEmptyString.error.message
+                            , details = NoTextEmptyString.error.details
+                            , under = "text \"\""
+                            }
+                            |> Review.Test.atExactly { start = { row = 9, column = 5 }, end = { row = 9, column = 12 } }
+                        ]
+        ]


### PR DESCRIPTION
Hello! 

I've been using [elm-review](https://package.elm-lang.org/packages/jfmengels/elm-review/latest/) and I wanted to make a rule to prevent using `text ""` all around my codebase. 

Let me know what you think of it! 